### PR TITLE
Convert :rubygems to secure URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 gem "json"
 


### PR DESCRIPTION
Fixes the bundler errors filling up my mailbox.

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
