### PR TITLE
The version number was fixed.

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -4,7 +4,7 @@ Redmine::Plugin.register :redmine_gitlab_hook do
   name 'Redmine GitLab Hook plugin'
   author 'Phlegx Systems'
   description 'This plugin allows your Redmine installation to receive GitLab post-receive notifications'
-  version '0.1.3'
+  version '0.2.0'
   url 'https://github.com/phlegx/redmine_gitlab_hook'
   author_url 'https://github.com/phlegx'
   requires_redmine :version_or_higher => '2.3.0'


### PR DESCRIPTION
The plugin version number of Redmine was fixed.
0.1.3 -> 0.2.0
