### PR TITLE
Fix #33 Need use string to get value in Setting.plugin_redmine_gitlab_hook

### DIFF
--- a/app/controllers/gitlab_hook_controller.rb
+++ b/app/controllers/gitlab_hook_controller.rb
@@ -11,7 +11,7 @@ class GitlabHookController < ActionController::Base
       repository = find_repository
       git_success = true
       # Fetch the changes from GitLab
-      if Setting.plugin_redmine_gitlab_hook[:fetch_updates] == 'yes'
+      if Setting.plugin_redmine_gitlab_hook['fetch_updates'] == 'yes'
         git_success = update_repository(repository)
       end
       if git_success
@@ -69,10 +69,10 @@ class GitlabHookController < ActionController::Base
 
   # Fetches updates from the remote repository
   def update_repository(repository)
-    Setting.plugin_redmine_gitlab_hook[:prune] == 'yes' ? prune = ' -p' : prune = ''
-    prefix = Setting.plugin_redmine_gitlab_hook[:git_command_prefix].to_s
+    Setting.plugin_redmine_gitlab_hook['prune'] == 'yes' ? prune = ' -p' : prune = ''
+    prefix = Setting.plugin_redmine_gitlab_hook['git_command_prefix'].to_s
 
-    if Setting.plugin_redmine_gitlab_hook[:all_branches] == 'yes'
+    if Setting.plugin_redmine_gitlab_hook['all_branches'] == 'yes'
       command = git_command(prefix, "fetch --all#{prune}", repository)
       exec(command)
     else
@@ -125,7 +125,7 @@ class GitlabHookController < ActionController::Base
     repository = project.repositories.find_by_identifier_param(repository_id)
 
     if repository.nil?
-      if Setting.plugin_redmine_gitlab_hook[:auto_create] == 'yes'
+      if Setting.plugin_redmine_gitlab_hook['auto_create'] == 'yes'
         repository = create_repository(project)
       else
         raise TypeError, "Project '#{project.to_s}' ('#{project.identifier}') has no repository or repository not found with identifier '#{repository_id}'"
@@ -142,15 +142,15 @@ class GitlabHookController < ActionController::Base
 
   def create_repository(project)
     logger.debug('Trying to create repository...')
-    raise TypeError, 'Local repository path is not set' unless Setting.plugin_redmine_gitlab_hook[:local_repositories_path].to_s.present?
+    raise TypeError, 'Local repository path is not set' unless Setting.plugin_redmine_gitlab_hook['local_repositories_path'].to_s.present?
 
     identifier = get_repository_identifier
     remote_url = params[:repository] && params[:repository][:git_ssh_url]
-    prefix = Setting.plugin_redmine_gitlab_hook[:git_command_prefix].to_s
+    prefix = Setting.plugin_redmine_gitlab_hook['git_command_prefix'].to_s
 
     raise TypeError, 'Remote repository URL is null' unless remote_url.present?
 
-    local_root_path = Setting.plugin_redmine_gitlab_hook[:local_repositories_path]
+    local_root_path = Setting.plugin_redmine_gitlab_hook['local_repositories_path']
     repo_namespace = get_repository_namespace
     repo_name = get_repository_name
     local_url = File.join(local_root_path, repo_namespace, repo_name)


### PR DESCRIPTION
After test, `Setting.plugin_redmine_gitlab_hook[:fetch_updates]` yield empty value :cry: 

Cannot use symbol to access value in Setting.plugin_redmine_gitlab_hook