### PR TITLE
Update app/controllers/gitlab_hook_controller.rb

### DIFF
--- a/app/controllers/gitlab_hook_controller.rb
+++ b/app/controllers/gitlab_hook_controller.rb
@@ -61,7 +61,7 @@ class GitlabHookController < ActionController::Base
 
 
   def git_command(prefix, command, repository)
-    "#{prefix} " + GIT_BIN + " --git-dir='#{repository.url}' #{command}"
+    "#{prefix} " + GIT_BIN + " --git-dir=\"#{repository.url}\" #{command}"
   end
 
 


### PR DESCRIPTION
Fix error "fatal: not a git repository" under Windows

Single quote in repo path under Windows throw error "fatal: not a git repository"